### PR TITLE
Update api.py : Fix donations crash

### DIFF
--- a/helloasso/members-sync-python-ci/src/hello_doli_gateway/helloasso/api.py
+++ b/helloasso/members-sync-python-ci/src/hello_doli_gateway/helloasso/api.py
@@ -96,6 +96,8 @@ class HelloAssoMembersAPI:
         hello_dict = {}
         num_hello_duplicates = 0
         for hellom in hellomem:
+            if "user" not in hellom:
+                continue
             full_name = crush(hellom['user']['firstName']) + crush(hellom['user']['lastName'])
             if full_name in hello_dict:
                 num_hello_duplicates += 1


### PR DESCRIPTION
Quand un don complémentaire est ajouté sur un formulaire d'adhésion, l'API retourne les dons individuellement.
Les dons n'ayant pas de clé 'user' cela provoque une KeyError: 'user' : 
```Traceback (most recent call last):
  File "/build/xxxxxxxxxxxxx/helloasso-memberships-to-dolibarr/push_helloasso_members_to_dolibarr.py", line 43, in <module>
    all_our_members_dict = hello.crush_and_remove_duplicates(all_our_members)
  File "/usr/local/lib/python3.13/site-packages/hello_doli_gateway/helloasso/api.py", line 99, in crush_and_remove_duplicates
    full_name = crush(hellom['user']['firstName']) + crush(hellom['user']['lastName'])
                      ~~~~~~^^^^^^^^
KeyError: 'user'
Cleaning up project directory and file based variables 00:00
ERROR: Job failed: exit code 1```